### PR TITLE
Fix circular dependency issue when installing mitdeeplearning in lab 1

### DIFF
--- a/lab1/PT_Part1_Intro.ipynb
+++ b/lab1/PT_Part1_Intro.ipynb
@@ -70,7 +70,7 @@
         "import torch.nn as nn\n",
         "\n",
         "# Download and import the MIT Introduction to Deep Learning package\n",
-        "!pip install mitdeeplearning --quiet\n",
+        "!pip install mitdeeplearning --upgrade --quiet\n",
         "import mitdeeplearning as mdl\n",
         "\n",
         "import numpy as np\n",


### PR DESCRIPTION
Before the change running the cell resulted in the following error which didn’t allow for the rest of the lab to be completed:
```
error: ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
gcsfs 2025.3.0 requires fsspec==2025.3.0, but you have fsspec 2024.12.0 which is incompatible.
```

Attempting to upgrade each library manually resulted in a dependency issue where different dependencies required different versions of the same library:
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
datasets 3.4.1 requires fsspec[http]<=2024.12.0,>=2023.1.0, but you have fsspec 2025.3.0 which is incompatible.
Successfully installed fsspec-2025.3.0
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
gcsfs 2025.3.0 requires fsspec==2025.3.0, but you have fsspec 2024.12.0 which is incompatible.
```

I assume this was fixed in `mitdeeplearning` so the upgrade fixes this issue.