### PR TITLE
Fix incorrect print variable for output result in sequential api task, PyTorch Lab 1

### DIFF
--- a/lab1/PT_Part1_Intro.ipynb
+++ b/lab1/PT_Part1_Intro.ipynb
@@ -426,7 +426,7 @@
         "model_output = model(x_input)\n",
         "print(f\"input shape: {x_input.shape}\")\n",
         "print(f\"output shape: {y.shape}\")\n",
-        "print(f\"output result: {y}\")"
+        "print(f\"output result: {model_output}\")"
       ]
     },
     {

--- a/lab1/solutions/PT_Part1_Intro_Solution.ipynb
+++ b/lab1/solutions/PT_Part1_Intro_Solution.ipynb
@@ -502,7 +502,7 @@
           "text": [
             "input shape: torch.Size([1, 2])\n",
             "output shape: torch.Size([1, 3])\n",
-            "output result: tensor([[0.7318, 0.9903, 0.9854]], grad_fn=<SigmoidBackward0>)\n"
+            "output result: tensor([[0.1982, 0.6723, 0.1635]], grad_fn=<SigmoidBackward0>)\n"
           ]
         }
       ],
@@ -512,7 +512,7 @@
         "model_output = model(x_input)\n",
         "print(f\"input shape: {x_input.shape}\")\n",
         "print(f\"output shape: {y.shape}\")\n",
-        "print(f\"output result: {y}\")"
+        "print(f\"output result: {model_output}\")"
       ]
     },
     {


### PR DESCRIPTION
Previously, the output result for the part where the model uses the Sequential API was printing the y variable, which was calculated for the previous task (OurDenseLayer), instead of the model_output variable which is the one properly calculating the output for this task. 

This mistake caused both prints to output the same tensor result, which is incorrect.